### PR TITLE
Make ItemIdentifier an optional attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 We follow [Semantic Versions](https://semver.org/).
 
+## Version 0.7.1
+
+- Make item_identifier optional in the SIRI VM model
+
 ## Version 0.7.0
 
 - Added `Siri` model to parse SIRI-VM responses from BODS

--- a/bods_client/models/siri.py
+++ b/bods_client/models/siri.py
@@ -100,7 +100,7 @@ class MonitoredVehicleJourney(BaseModel):
 
 class VehicleActivity(BaseModel):
     recorded_at_time: datetime
-    item_identifier: str
+    item_identifier: Optional[str]
     valid_until_time: datetime
     monitored_vehicle_journey: MonitoredVehicleJourney
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry]
 name = "bods-client"
 description = "A Python client for the Department for Transport Bus Open Data Service API"
-version = "0.7.0"
+version = "0.7.1"
 license = "MIT"
 
 authors = ["Ciaran McCormick"]


### PR DESCRIPTION
Made the item_identifier field optional on the Pydantic model
as it may not be present in a Siri response.