### PR TITLE
Fix #40

### DIFF
--- a/bods_client/models/timetables.py
+++ b/bods_client/models/timetables.py
@@ -54,12 +54,14 @@ class TimetableParams(BaseAPIParams):
         """Custom dict method to convert list of noc strings to a cvs.
 
         There's a bug in the BODS timetables API where ?noc=NOC1&noc=NOC2
-        only recognises the last parameter.
+        only recognises the last parameter. This also applies to adminArea too.
         """
         dict_ = super().dict(*args, **kwargs)
 
         if "noc" in dict_:
             dict_["noc"] = ",".join(dict_.get("noc", []))
+        if "adminArea" in dict_:
+            dict_["adminArea"] = ",".join(dict_.get("adminArea", []))
         return dict_
 
 


### PR DESCRIPTION
Allows all administrative areas passed to the Timetable API to be parsed and used -- currently only last value gets used.